### PR TITLE
Enable clickAnalytics = true, when analytics = true

### DIFF
--- a/app/src/instantsearch.js
+++ b/app/src/instantsearch.js
@@ -44,6 +44,7 @@ class InstantSearch {
       },
       searchParameters: {
         analytics,
+        clickAnalytics: analytics,
         attributesToSnippet: ['body_safe:40'],
         highlightPreTag: '<span class="ais-highlight">',
         highlightPostTag: '</span>',


### PR DESCRIPTION
Sourced from https://www.algolia.com/doc/guides/getting-insights-and-analytics/search-analytics/click-through-and-conversions/how-to/send-click-and-conversion-events-with-instantsearch/js/