### PR TITLE
feat(crawler): option to exclude portions of articles from indexing

### DIFF
--- a/crawler/README.md
+++ b/crawler/README.md
@@ -24,7 +24,7 @@ bundle exec ./run
 
 You can generate an API token to your Zendesk instance in the *Agent Section* > *Admin/Settings* > *API*.
 
-Otherwise (and this is what we use when plugging the connector to Algolia), you can use an OAuth token whiche has the `hc:read` scope.  
+Otherwise (and this is what we use when plugging the connector to Algolia), you can use an OAuth token which has the `hc:read` scope.  
 If you have one, just replace the `CONFIG` line with
 
 ```sh
@@ -40,6 +40,21 @@ CONFIG='{ "app_name": "your-zendesk-subdomain", "oauth_token": "xxx" }' \
 * `private` - *optional* - Default: `false` - Set to true to index all articles, regardless of their user segment
 * `max_content_size` - *optional* - Default: `5000` - Maximum byte size after which the text of an attribute will be truncated
 
+## Excluding portions of article from indexing
+To prevent certain specific portion of your article to be indexed to Algolia, you can wrap the html source code of these portion between `<!-- algolia-ignore --> <!-- /algolia-ignore -->` tags. This way, these portions of text won't be searchable. 
+
+Example: 
+```html
+<h1>This is a test article</h1>
+<!-- algolia-ignore -->
+<p>
+  This paragraph won't be indexed to Algolia.
+</p>
+<!-- /algolia-ignore -->
+<p>
+  This paragraph will be indexed to Algolia.
+</p>
+```
 
 ## Contributing
 

--- a/crawler/item.rb
+++ b/crawler/item.rb
@@ -97,8 +97,11 @@ module ZendeskIntegration::V2::Zendesk
     end
 
     def decode body
-      ZendeskIntegration::V2::DECODER.decode(body.to_s.gsub(/<\/?[^>]*>/, ' '))
+      body_without_comments = body.to_s.gsub(/(<!--) +(algolia-ignore) +(-->).+?\1 +\/\2 +\3/m, '')
+      body_without_html = body_without_comments.gsub(/<\/?[^>]*>/, ' ')
+      ZendeskIntegration::V2::DECODER.decode(body_without_html)
     end
+
 
     def truncate str, max
       truncated = str.length > max

--- a/crawler/item.rb
+++ b/crawler/item.rb
@@ -102,7 +102,6 @@ module ZendeskIntegration::V2::Zendesk
       ZendeskIntegration::V2::DECODER.decode(body_without_html)
     end
 
-
     def truncate str, max
       truncated = str.length > max
       res = str[0...max]

--- a/crawler/item.rb
+++ b/crawler/item.rb
@@ -97,9 +97,8 @@ module ZendeskIntegration::V2::Zendesk
     end
 
     def decode body
-      body_without_comments = body.to_s.gsub(/(<!--) +(algolia-ignore) +(-->).+?\1 +\/\2 +\3/m, '')
-      body_without_html = body_without_comments.gsub(/<\/?[^>]*>/, ' ')
-      ZendeskIntegration::V2::DECODER.decode(body_without_html)
+      body_without_tags = body.to_s.gsub(/(<!--) +(algolia-ignore) +(-->).+?\1 +\/\2 +\3/m, '').gsub(/<\/?[^>]*>/, ' ')
+      ZendeskIntegration::V2::DECODER.decode(body_without_tags)
     end
 
     def truncate str, max


### PR DESCRIPTION
Add option to exclude certain portion of an article to be indexed to Algolia by wrapping it between `<!-- algolia-ignore -->` `<!-- /algolia-ignore -->` comments. 

**Test:** 
Article in Zendesk HC: 
![image](https://user-images.githubusercontent.com/39140360/68047440-b28c7700-fcde-11e9-8095-96d5a01aa6d3.png)

Record in Algolia: 
![image](https://user-images.githubusercontent.com/39140360/68047589-0c8d3c80-fcdf-11e9-8647-0ad68ddf7cb3.png)

