### PR TITLE
feat(app): add support for conversions

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -84,7 +84,7 @@ Here is a full breakdown of the available options for the JavaScript library:
     analytics: true,                      // should queries be processed by Algolia analytics
     baseUrl: '/hc/',                      // the base URL of your Help Center
     poweredBy: true,                      // show the "Search by Algolia" link (required if you're on Algolia's FREE plan)
-    clickAnalytics: false,                // wether or not to enable the clikAnalytics feature (available on the Enterprise plan)
+    clickAnalytics: false,                // whether or not to enable the clickAnalytics feature (available on the Enterprise plan)
     debug: false,                         // debug mode prevents the autocomplete to close when trying to inspect it
     color: '#158EC2',                     // main color (used for links)
     highlightColor: '#158EC2',            // highlight color to emphasize matching text

--- a/app/README.md
+++ b/app/README.md
@@ -300,6 +300,14 @@ For `en-au`, `en-ca` and `en-us` locales, we'll index `{ "label_names": ["Awesom
 For the `en-gb` locale, we'll index `{ "label_names": ["Good"] }`.
 For all the other locales, we'll index `{ "label_names": ["Wow"] }`.
 
+### Analytics
+
+The `analytics` parameter enables searches capturing, for reports about popular queries, searches without results, and more. It defaults to `true`.
+
+The `clickAnalytics` parameter enables click capturing in search results, for reports about the click rate and average position of clicks for specific queries. It defaults to `false`, as this feature is only accessible on our Enterprise plan.
+
+With `clickAnalytics` enabled, you can use `algoliasearchZendeskHC.trackConversion()` on an article page to capture a “conversion” if your articles include Calls To Action.
+
 ### Zendesk Community search
 
 We do not index community forums for now. If you're using them, you'll probably want to disable `instantsearch` by setting `enabled: false` and just use the auto-complete feature.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1750,6 +1750,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -4607,7 +4608,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4628,12 +4630,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4648,17 +4652,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4775,7 +4782,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4787,6 +4795,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4801,6 +4810,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4808,12 +4818,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4832,6 +4844,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4912,7 +4925,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4924,6 +4938,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5009,7 +5024,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5045,6 +5061,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5064,6 +5081,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5107,12 +5125,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5971,7 +5991,8 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hogan.js": {
       "version": "3.0.2",
@@ -7031,6 +7052,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
       "dev": true
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "1.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "autocomplete.js": "^0.28.1",
     "hogan.js": "^3.0.2",
     "instantsearch.js": "^1.0.0",
+    "js-cookie": "^2.2.1",
     "stopwords": "https://github.com/6/stopwords/tarball/ccec79a4ba22d65eb095bc277d79a7ad8096552c",
     "unorm": "^1.4.1",
     "vietnamese-stopwords": "0.0.2"

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -194,7 +194,7 @@ class Autocomplete {
   _onSelected(baseUrl, locale, clickAnalytics) {
     return (event, suggestion, dataset) => {
       if (clickAnalytics) {
-        const {objectID, _position, _queryID} = suggestion;
+        const {_position, _queryID} = suggestion;
         this.trackClick(suggestion, _position, _queryID);
       }
       location.href = `${baseUrl}${locale}/${dataset}/${suggestion.id}`;

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -11,7 +11,7 @@ import autocomplete from 'autocomplete.js';
 import zepto from 'autocomplete.js/zepto.js';
 
 import algoliasearch from 'algoliasearch';
-import {initInsights, enableTrackClick} from './clickAnalytics.js';
+import {createClickTracker} from './clickAnalytics.js';
 
 
 import addCSS from './addCSS.js';
@@ -30,15 +30,10 @@ class Autocomplete {
       enabled,
       inputSelector
     },
-    clickAnalytics,
     indexPrefix,
     subdomain
   }) {
     if (!enabled) return;
-
-    if (clickAnalytics) {
-      initInsights(applicationId, apiKey);
-    }
 
     this._temporaryHiding(inputSelector);
 
@@ -46,7 +41,7 @@ class Autocomplete {
     this.client.addAlgoliaAgent('Zendesk Integration (__VERSION__)');
     this.indexName = `${indexPrefix}${subdomain}_articles`;
     this.index = this.client.initIndex(this.indexName);
-    this.trackClick = enableTrackClick(this.indexName);
+    this.trackClick = createClickTracker(this, this.indexName);
   }
 
   render({
@@ -200,7 +195,7 @@ class Autocomplete {
     return (event, suggestion, dataset) => {
       if (clickAnalytics) {
         const {objectID, _position, _queryID} = suggestion;
-        this.trackClick(objectID, _position, _queryID);
+        this.trackClick(suggestion, _position, _queryID);
       }
       location.href = `${baseUrl}${locale}/${dataset}/${suggestion.id}`;
     };

--- a/app/src/clickAnalytics.js
+++ b/app/src/clickAnalytics.js
@@ -1,5 +1,6 @@
+import cookies from 'js-cookie';
 
-export function initInsights(appId, apiKey) {
+export function initInsights({applicationId, apiKey}) {
   const ALGOLIA_INSIGHTS_SRC = 'https://cdn.jsdelivr.net/npm/search-insights@1';
 
   /* eslint-disable */
@@ -9,21 +10,55 @@ export function initInsights(appId, apiKey) {
   }(window,document,"script",0,"aa");
   /* eslint-enable */
 
-  window.aa('init', {
-    appId,
-    apiKey
-  });
+  window.aa('init', {appId: applicationId, apiKey});
 }
 
 
-export function enableTrackClick(index) {
-  return function trackClick(objectID, position, queryID) {
+export function createClickTracker(self, index) {
+  return function trackClick(article, position, queryID) {
+    if (!window.aa) return;
+    if (self._saveLastClick) self._saveLastClick(queryID, article);
     window.aa('clickedObjectIDsAfterSearch', {
       eventName: 'article_clicked',
       index,
       queryID,
-      objectIDs: [objectID],
+      objectIDs: [article.objectID],
       positions: [Number(position)]
     });
+  };
+}
+
+// Extends instance with clickAnalytics specific attributes
+export function extendWithConversionTracking(self, {clickAnalytics, indexPrefix, subdomain}) {
+  const indexName = `${indexPrefix}${subdomain}_articles`;
+
+  if (!clickAnalytics) {
+    self._saveLastQueryID = () => {};
+    self._saveLastClick = () => {};
+    self.trackConversion = () => {};
+    return;
+  }
+
+  self._saveLastClick = (queryID, article) => {
+    const cookieBody = JSON.stringify({queryID, objectID: article.objectID, articleID: article.id});
+    cookies.set('algolia-last-click', cookieBody, {expires: 1});
+  };
+  self.trackConversion = articleID => {
+    const lastClickRaw = cookies.get('algolia-last-click');
+    if (!lastClickRaw) return;
+    const lastClick = JSON.parse(lastClickRaw);
+
+    if (!lastClick.queryID || !lastClick.objectID || !lastClick.articleID) return;
+
+    if (articleID !== lastClick.articleID) return;
+
+    window.aa('convertedObjectIDsAfterSearch', {
+      index: indexName,
+      eventName: 'article_conversion',
+      queryID: lastClick.queryID,
+      objectIDs: [lastClick.objectID]
+    });
+
+    self._saveLastClick(lastClick.queryID, {});
   };
 }

--- a/app/src/instantsearch.js
+++ b/app/src/instantsearch.js
@@ -1,5 +1,5 @@
 import instantsearch from 'instantsearch.js';
-import {initInsights, enableTrackClick} from './clickAnalytics.js';
+import {createClickTracker} from './clickAnalytics.js';
 
 import addCSS from './addCSS.js';
 import removeCSS from './removeCSS.js';
@@ -28,13 +28,9 @@ class InstantSearch {
   }) {
     if (!enabled) return;
 
-    if (clickAnalytics) {
-      initInsights(applicationId, apiKey);
-    }
-
     this.locale = null;
     this.indexName = `${indexPrefix}${subdomain}_articles`;
-    this.trackClick = enableTrackClick(this.indexName);
+    this.trackClick = createClickTracker(this, this.indexName);
 
     this._temporaryHiding({
       hideAutocomplete,
@@ -366,9 +362,10 @@ class InstantSearch {
         return;
       }
       const objectID = $article.getAttribute('data-algolia-objectid');
+      const articleID = $article.getAttribute('data-algolia-articleid');
       const position = $article.getAttribute('data-algolia-position');
       const queryID = $article.getAttribute('data-algolia-queryid');
-      this.trackClick(objectID, position, queryID);
+      this.trackClick({objectID, articleID}, position, queryID);
     });
   }
 }

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -193,7 +193,13 @@ const defaultTemplates = {
 
     // Instant search result template
     hit: compile(
-`<div class="search-result" data-algolia-position="[[ position ]]" data-algolia-queryid="[[ queryID ]]" data-algolia-objectid="[[ objectID ]]">
+`<div
+  class="search-result"
+  data-algolia-position="[[ position ]]"
+  data-algolia-queryid="[[ queryID ]]"
+  data-algolia-articleid="[[ id ]]"
+  data-algolia-objectid="[[ objectID ]]"
+>
   <div class="search-result-meta">
     <time data-datetime="relative" datetime="[[ created_at_iso ]]"></time>
   </div>

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -76,7 +76,7 @@ Here is a full breakdown of the available options for the JavaScript library:
     analytics: true,                      // should queries be processed by Algolia analytics
     baseUrl: '/hc/',                      // the base URL of your Help Center
     poweredBy: true,                      // show the "Search by Algolia" link (required if you're on Algolia's FREE plan)
-    clickAnalytics: false,                // wether or not to enable the clikAnalytics feature (available on the Enterprise plan)
+    clickAnalytics: false,                // whether or not to enable the clickAnalytics feature (available on the Enterprise plan)
     debug: false,                         // debug mode prevents the autocomplete to close when trying to inspect it
     color: '#158EC2',                     // main color (used for links)
     highlightColor: '#158EC2',            // highlight color to emphasize matching text

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -292,6 +292,14 @@ For `en-au`, `en-ca` and `en-us` locales, we'll index `{ "label_names": ["Awesom
 For the `en-gb` locale, we'll index `{ "label_names": ["Good"] }`.
 For all the other locales, we'll index `{ "label_names": ["Wow"] }`.
 
+## Analytics
+
+The `analytics` parameter enables searches capturing, for reports about popular queries, searches without results, and more. It defaults to `true`.
+
+The `clickAnalytics` parameter enables click capturing in search results, for reports about the click rate and average position of clicks for specific queries. It defaults to `false`, as this feature is only accessible on our Enterprise plan.
+
+With `clickAnalytics` enabled, you can use `algoliasearchZendeskHC.trackConversion()` on an article page to capture a “conversion” if your articles include Calls To Action.
+
 ## Zendesk Community search
 
 We do not index community forums for now. If you're using them, you'll probably want to disable `instantsearch` by setting `enabled: false` and just use the auto-complete feature.


### PR DESCRIPTION
This PR introduces support for conversion events.
Had to modify quite a lot of things here!

To summarize:
* If `clickAnalytics` is `true`, on each click, save in a cookie the queryID, objectID (translation ID) and articleID.
* Expose a method `algoliasearchZendeskHC.trackConversion([articleID])`