### PR TITLE
fix(crawler) crawler for posts is not work

### DIFF
--- a/crawler/types/post.rb
+++ b/crawler/types/post.rb
@@ -29,7 +29,7 @@ module ZendeskIntegration::V2::Zendesk
       super.merge(
         title: @zendesk_obj.title,
         topic: topic.simple,
-        details: truncate(decode(@zendesk_obj.details)),
+        details: truncate(decode(@zendesk_obj.details), @crawler.config['max_content_size']),
         featured: @zendesk_obj.featured,
         closed: @zendesk_obj.closed,
         comments: {


### PR DESCRIPTION
## Why

crawler for posts is not work for the following reason.

- function of `truncate` needs two arguments but only given one  in `posts`.

    ```shell
    Traceback (most recent call last):
      14: from ./run:7:in `<main>'
      13: from /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/algoliasearch-zendeskv2.rb:37:in `run'
      12: from /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/crawler.rb:102:in `crawl_and_index'
      11: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:216:in `all!'
      10: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:342:in `_all'
      9: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:298:in `method_missing'
      8: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:457:in `array_method'
      7: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:457:in `public_send'
      6: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:457:in `each'
      5: from /Users/chick-p/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/zendesk_api_client_rb-e94ecce851ff/lib/zendesk_api/collection.rb:349:in `block in _all'
      4: from /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/crawler.rb:103:in `block in crawl_and_index'
      3: from /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/crawler.rb:103:in `new'
      2: from /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/item.rb:70:in `initialize'
      1: from /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/types/post.rb:32:in `build'
    /Users/chick-p/repos/github.com/algolia/algoliasearch-zendesk/crawler/item.rb:104:in `truncate': wrong number of arguments (given 1, expected 2) (ArgumentError)
    ```

## What

- given max of content size to second argument (4e3b8f6)
