### PR TITLE
fix(2.30.0): revert hit template to property instead of function

### DIFF
--- a/app/src/instantsearch.js
+++ b/app/src/instantsearch.js
@@ -205,7 +205,7 @@ class InstantSearch {
         hitsPerPage,
         templates: {
           empty: templates.instantsearch.noResult,
-          item: templates.instantsearch.hit(useEditedAt)
+          item: templates.instantsearch.hit
         },
         transformData: {
           empty: data => ({
@@ -214,6 +214,7 @@ class InstantSearch {
           }),
           item: hit => ({
             ...hit,
+            useEditedAt,
             baseUrl,
             position: hit.__hitIndex + 1,
             queryID: this.instantsearch.helper.lastResults._rawResults[0].queryID

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -201,7 +201,7 @@ const defaultTemplates = {
   data-algolia-objectid="[[ objectID ]]"
 >
   <div class="search-result-meta">
-    <time data-datetime="relative" datetime="[[# useEditedAt ]] [[ edited_at_iso ]] [[/ useEditedAt]][[^ useEditedAt ]] [[ created_at_iso ]] [[/ useEditedAt  ]]"></time>
+    <time data-datetime="relative" datetime="[[# useEditedAt ]][[ edited_at_iso ]][[/ useEditedAt]][[^ useEditedAt ]][[ created_at_iso ]][[/ useEditedAt  ]]"></time>
   </div>
   <div class="search-result-link-wrapper">
     <a class="search-result-link" href="[[ baseUrl ]][[ locale.locale ]]/articles/[[ id ]]">

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -192,7 +192,7 @@ const defaultTemplates = {
     ),
 
     // Instant search result template
-    hit: useEditedAt => compile(
+    hit: compile(
 `<div
   class="search-result"
   data-algolia-position="[[ position ]]"
@@ -201,7 +201,7 @@ const defaultTemplates = {
   data-algolia-objectid="[[ objectID ]]"
 >
   <div class="search-result-meta">
-    <time data-datetime="relative" datetime="[[ ${ useEditedAt ? 'edited_at_iso' : 'created_at_iso'} ]]"></time>
+    <time data-datetime="relative" datetime="[[# useEditedAt ]] [[ edited_at_iso ]] [[/ useEditedAt]][[^ useEditedAt ]] [[ created_at_iso ]] [[/ useEditedAt  ]]"></time>
   </div>
   <div class="search-result-link-wrapper">
     <a class="search-result-link" href="[[ baseUrl ]][[ locale.locale ]]/articles/[[ id ]]">


### PR DESCRIPTION
- useEditedAt now passed through hogan