### PR TITLE
fix: use bash in release scripts

### DIFF
--- a/scripts/release-app.sh
+++ b/scripts/release-app.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # Exit on error
 set -e

--- a/scripts/release-docs.sh
+++ b/scripts/release-docs.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # Exit on error
 set -e
@@ -7,7 +7,7 @@ set -e
 if [[ $ALGOLIASEARCH_ZENDESK_VERSION == "" ]]; then
   current=`json -f package.json version`
   read -p "New version number (current is ${current}): " version
-  export ALGOLIASEARCH_ZENDESK_VERSION=$version
+  export ALGOLIASEARCH_ZENDESK_VERSION=${version:-$current}
 fi
 
 # Ask for confirmation

--- a/scripts/release-git.sh
+++ b/scripts/release-git.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # Exit on error
 set -e

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # Exit on error
 set -e

--- a/scripts/test_crawler.sh
+++ b/scripts/test_crawler.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 APPLICATION_ID='' \
 API_KEY='' \


### PR DESCRIPTION
When trying to update the documentation I got the following errors:
```
$ npm run release:docs

> algoliasearch.zendesk-hc.tools@2.30.1 release:docs /home/sylvain/dev/algoliasearch/algoliasearch-zendesk
> ./scripts/release-docs.sh

./scripts/release-docs.sh: 7: [[: not found
./scripts/release-docs.sh: 14: read: Illegal option -n
```

This is because some syntax is not supported by `sh`: https://stackoverflow.com/a/3401197/1326281


Also: Use the version from `package.json` by default when the input is empty