### PR TITLE
fix: add indexName option

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,11 +1,6 @@
 # JavaScript library: `algoliasearchZendeskHC`
 
 [![npm](https://img.shields.io/npm/v/algoliasearch.zendesk-hc.png)](https://www.npmjs.com/package/algoliasearch.zendesk-hc)
-
-[![Dependency Status](https://david-dm.org/algolia/algoliasearch-zendesk.png?path=app)](https://david-dm.org/algolia/algoliasearch-zendesk?path=app)
-[![devDependency Status](https://david-dm.org/algolia/algoliasearch-zendesk/dev-status.png?path=app)](https://david-dm.org/algolia/algoliasearch-zendesk?path=app#info=devDependencies)
-[![peerDependency Status](https://david-dm.org/algolia/algoliasearch-zendesk/peer-status.png?path=app)](https://david-dm.org/algolia/algoliasearch-zendesk?path=app#info=peerDependencies)
-
 [![GitHub license](https://img.shields.io/github/license/algolia/algoliasearch-zendesk.png)](../LICENSE)
 
 This JavaScript library allows you to replace the default search of your Zendesk Help Center by Algolia. [Algolia](https://www.algolia.com) is a hosted full-text, numerical, and faceted search engine capable of delivering realtime results from the first keystroke.
@@ -37,7 +32,7 @@ This connector will every day take your public Help Center articles and put them
 In most cases, this should be enough to have an up-to-date search.
 
 However, if you'd rather have it updated sooner, you can manually trigger a full reindex.
-On this page, click the "Reindex" button in the bottom right corner. An indexing job will be pushed in our indexing queue. Depending on the load of the queue, it might take up to a few hours for your search index to be updated.
+On your [Connectors](https://dashboard.algolia.com/connectors/tasks) page, click the "Run task" button on the right of your task.
 
 ### Updating your Help Center theme
 
@@ -76,11 +71,11 @@ Here is a full breakdown of the available options for the JavaScript library:
     applicationId: '<YOUR APPLICATION_ID>',
     apiKey: '<YOUR SEARCH ONLY API KEY>',
     subdomain: '<YOUR ZENDESK APPLICATION NAME>',
+    indexName: '<YOUR ALGOLIA INDEX NAME>',
 
     //
     // Optional configuration:
     //
-    indexPrefix: 'zendesk_',              // or your custom <INDEX_PREFIX>
     analytics: true,                      // should queries be processed by Algolia analytics
     baseUrl: '/hc/',                      // the base URL of your Help Center
     poweredBy: true,                      // show the "Search by Algolia" link (required if you're on Algolia's FREE plan)
@@ -105,6 +100,7 @@ Here is a full breakdown of the available options for the JavaScript library:
       useEditedAt: false                  // show edited_at timestamp in search results
     },
     instantsearchPage,                    // function to check if we're on the search page
+    indexPrefix: 'zendesk_',              // @deprecated use `indexName` instead
     templates: {                          // template objects (see the templates section)
       autocomplete: {},
       instantsearch: {}
@@ -363,9 +359,8 @@ Also, some templates are using a `compile` function in this file. This function 
 
 In case you're using Zendesk's [IP restrictions feature](https://support.zendesk.com/hc/en-us/articles/203663706-Restricting-access-to-Zendesk-Support-and-your-Help-Center-using-IP-restrictions), you'll need to whitelist our IPs for our indexing to work.
 Here are those IPs:
-- `3.221.200.5`
-- `52.204.20.39`
-- `52.22.248.248`
+- `104.196.103.173`
+- `35.234.69.129`
 
 ## Development
 
@@ -430,6 +425,7 @@ When running, you can then add this custom script to your Help Center, inside th
     applicationId: 'FIXME',
     apiKey: 'FIXME',
     subdomain: 'FIXME',
+    indexName: 'FIXME',
   })
 </script>
 ```

--- a/app/README.md
+++ b/app/README.md
@@ -17,7 +17,7 @@ To browse through the crawler, visit the [crawler/](../crawler/) folder.
 ### Synchronize Algolia with your Help Center
 
 <div align="center">
-  <img src="https://community.algolia.com/zendesk/img/algolia-zendesk.svg" alt="Data connection visualization" />
+  <img src="https://www.algolia.com/_next/image/?url=https%3A%2F%2Fres.cloudinary.com%2Fhilnmyskv%2Fimage%2Fupload%2Fv1671027406%2FAlgolia_com_Website_assets%2Fimages%2Fzendesk%2FZendesk-algolia.png&w=1200&q=75" alt="Data connection visualization" />
 </div>
 
 1. Create an [Algolia account](https://www.algolia.com/users/sign_up).

--- a/app/index.html
+++ b/app/index.html
@@ -61,6 +61,7 @@
         applicationId: 'latency',
         apiKey: '88209bb425570ef10733c0ba3157bac3',
         subdomain: 'algolia-test',
+        indexName: 'zendesk_algolia-test_articles',
         color: '#158EC2',
         highlightColor: '#F08',
         autocomplete: {

--- a/app/src/AlgoliasearchZendeskHC.js
+++ b/app/src/AlgoliasearchZendeskHC.js
@@ -59,6 +59,7 @@ const optionsStructure = {
     poweredBy: { type: 'boolean', value: true },
     responsive: { type: 'boolean', value: true },
     subdomain: { type: 'string', required: true },
+    indexName: { type: 'string', value: false},
     templates: {
       type: 'Object',
       value: {},

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -24,6 +24,7 @@ class Autocomplete {
     applicationId,
     apiKey,
     autocomplete: { enabled, inputSelector },
+    indexName,
     indexPrefix,
     subdomain,
   }) {
@@ -33,7 +34,7 @@ class Autocomplete {
 
     this.client = algoliasearch(applicationId, apiKey);
     this.client.addAlgoliaAgent('Zendesk Integration (__VERSION__)');
-    this.indexName = `${indexPrefix}${subdomain}_articles`;
+    this.indexName = indexName || `${indexPrefix}${subdomain}_articles`;
     this.index = this.client.initIndex(this.indexName);
     this.trackClick = createClickTracker(this, this.indexName);
   }

--- a/app/src/clickAnalytics.js
+++ b/app/src/clickAnalytics.js
@@ -30,9 +30,9 @@ export function createClickTracker(self, index) {
 // Extends instance with clickAnalytics specific attributes
 export function extendWithConversionTracking(
   self,
-  { clickAnalytics, indexPrefix, subdomain }
+  { clickAnalytics, indexName, indexPrefix, subdomain }
 ) {
-  const indexName = `${indexPrefix}${subdomain}_articles`;
+  const finalIndexName = indexName || `${indexPrefix}${subdomain}_articles`;
 
   if (!clickAnalytics) {
     self._saveLastQueryID = () => {};
@@ -60,7 +60,7 @@ export function extendWithConversionTracking(
     if (articleID !== lastClick.articleID) return;
 
     window.aa('convertedObjectIDsAfterSearch', {
-      index: indexName,
+      index: finalIndexName,
       eventName: 'article_conversion',
       queryID: lastClick.queryID,
       objectIDs: [lastClick.objectID],

--- a/app/src/instantsearch.js
+++ b/app/src/instantsearch.js
@@ -14,6 +14,7 @@ class InstantSearch {
     apiKey,
     autocomplete: { inputSelector: autocompleteSelector },
     clickAnalytics,
+    indexName,
     indexPrefix,
     instantsearch: { enabled, hideAutocomplete, paginationSelector, selector },
     subdomain,
@@ -21,7 +22,7 @@ class InstantSearch {
     if (!enabled) return;
 
     this.locale = null;
-    this.indexName = `${indexPrefix}${subdomain}_articles`;
+    this.indexName = indexName || `${indexPrefix}${subdomain}_articles`;
     this.trackClick = createClickTracker(this, this.indexName);
 
     this._temporaryHiding({

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -356,6 +356,5 @@ Also, some templates are using a `compile` function in this file. This function 
 
 In case you're using Zendesk's [IP restrictions feature](https://support.zendesk.com/hc/en-us/articles/203663706-Restricting-access-to-Zendesk-Support-and-your-Help-Center-using-IP-restrictions), you'll need to whitelist our IPs for our indexing to work.
 Here are those IPs:
-- `3.221.200.5`
-- `52.204.20.39`
-- `52.22.248.248`
+- `104.196.103.173`
+- `35.234.69.129`

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -68,11 +68,11 @@ Here is a full breakdown of the available options for the JavaScript library:
     applicationId: '<YOUR APPLICATION_ID>',
     apiKey: '<YOUR SEARCH ONLY API KEY>',
     subdomain: '<YOUR ZENDESK APPLICATION NAME>',
+    indexName: '<YOUR ALGOLIA INDEX NAME>',
 
     //
     // Optional configuration:
     //
-    indexPrefix: 'zendesk_',              // or your custom <INDEX_PREFIX>
     analytics: true,                      // should queries be processed by Algolia analytics
     baseUrl: '/hc/',                      // the base URL of your Help Center
     poweredBy: true,                      // show the "Search by Algolia" link (required if you're on Algolia's FREE plan)
@@ -97,6 +97,7 @@ Here is a full breakdown of the available options for the JavaScript library:
       useEditedAt: false                  // show edited_at timestamp in search results
     },
     instantsearchPage,                    // function to check if we're on the search page
+    indexPrefix: 'zendesk_',              // @deprecated use `indexName` instead
     templates: {                          // template objects (see the templates section)
       autocomplete: {},
       instantsearch: {}

--- a/scripts/test-front.js
+++ b/scripts/test-front.js
@@ -9,7 +9,7 @@ var lib = document.createElement('script'); lib.type = 'text/javascript'; lib.in
       apiKey: '',
       subdomain: '',
       poweredBy: false,
-      indexPrefix: 'zendesk_',
+      indexName: 'my_zendesk_articles',
       autocomplete: {
         enabled: true, // is the autocomplete feature enabled?
         inputSelector: '#query', // the DOM selector to select the search box


### PR DESCRIPTION
The crawler now runs on the Data Ingestion Platform, and the `indexName` is defined by the user directly so we need to support all `indexName`.
If the user doesn't provide an `indexName` if will fallback to `${indexPrefix}${subdomain}_articles` like before.

Also update the logo and the documentation.