### PR TITLE
update reference to support@aloglia.com to new ticket link

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "algoliasearch.zendesk-hc",
   "version": "2.32.0",
   "description": "Algolia Search for Zendesk's Help Center",
-  "author": "Algolia <support@algolia.com>",
+  "author": "Algolia <https://alg.li/support>",
   "keywords": [
     "algolia",
     "search",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "algoliasearch.zendesk-hc.tools",
   "description": "Algolia Search for Zendesk's Help Center. This private project is used for the tools and scripts at the root of the repository.",
-  "author": "Algolia <support@algolia.com>",
+  "author": "Algolia <https://alg.li/support>",
   "version": "2.32.0",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Hey team!
The Support team is currently in a process of removing support@algolia.com email from all GitHub repos and updating it to link to the new ticket form https://alg.li/support. We kindly ask that you review the changes made removing references to support@algolia.com
Thanks!

Is it possible to also remove the reference to the email here: https://github.com/algolia/algoliasearch-zendesk/blob/master/marketplace/manifest.json#L5 - as I was unsure whether it was possible to remove the line entirely?