### PR TITLE
feat(deps): upgrade algoliasearch v4 -> v5

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -437,6 +437,26 @@ In this case, you'll need to authorize insecure loading.
 This will most often be hidden behind a shield icon or the green lock icon in your location bar.  
 For instance, on Firefox: click the lock icon in the location bar > Right arrow with label "Show connection details" > Disable protection for now
 
+### Bundling note: `algoliasearch/lite`
+
+Both `app/src/autocomplete.js` and `app/src/instantsearch.js` import the search-only [lite client](https://www.npmjs.com/package/algoliasearch) from `algoliasearch/lite`.
+
+[`algoliasearch`](https://github.com/algolia/algoliasearch-client-javascript) ships per-environment builds via the package.json `exports` field (a Node build that uses `node:zlib`, a browser UMD build that doesn't).
+Our [Browserify](https://browserify.org/) version pre-dates `exports` support, so it falls back to the package's `lite.js` shim which always points at the Node build. That pulls in `browserify-zlib` and adds ~1.2 MB to the bundle for no runtime benefit.
+
+To work around it, the `browser` field in `package.json` aliases `algoliasearch/lite` to the self-contained UMD browser build:
+```json
+"browser": {
+  "algoliasearch/lite": "./node_modules/algoliasearch/dist/lite/builds/browser.umd.js"
+}
+```
+
+To measure the bundle:
+```sh
+npm run build:js
+du -h dist/algoliasearch.zendesk-hc.js
+```
+
 ### Documentation
 
 To update the documentation of the project, you only need to update this README.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.32.0",
       "license": "MIT",
       "dependencies": {
-        "algoliasearch": "^4.27.0",
+        "algoliasearch": "^5.52.1",
         "autocomplete.js": "^0.28.1",
         "hogan.js": "^3.0.2",
         "instantsearch.js": "^4.96.1",
@@ -76,83 +76,118 @@
         "node": ">=22"
       }
     },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.27.0.tgz",
-      "integrity": "sha512-YGog2s57sO20lvpa+hv5XLAAmiTI1kHsCMRtPVfiaOdIQnvRla21lfH08onqEbZihOPVI8GULwt79zQB2ymKzg==",
+    "node_modules/@algolia/abtesting": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.1.tgz",
+      "integrity": "sha512-aehCadlWOGvrT91KUIZpC0MbB8KBW9yUuvTJFd2xesR7le/IsT4nJUnjCCZ4ZqZCeTcPHPV5mo//fZ5oxcSVYw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.27.0.tgz",
-      "integrity": "sha512-Sr8zjNXj82p6lO4W9CdzfF0m0/9h/H6VAdSHOTtimm/cTzXIYXRI2IZq7+Nt2ljJ7Ukx+7dIFcxQjE57eQSPsw==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.27.0.tgz",
-      "integrity": "sha512-abgMRTcVD0IllNvMM9JFhxtyLn1v6Ey7mQ7+BGS3JCzvkCX7KZqlS0BIuVUDgx9sPIfOeNsG/awGzMmP50TwZw==",
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.1.tgz",
+      "integrity": "sha512-HmXOGBOAOJPounpBzBpuY0zDYeiCpxgHnQmuA7JO6ScukcBdGp3/XM9zJk5pJx/xNGD68mbPGXWpDxGtl6BwDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.27.0.tgz",
-      "integrity": "sha512-sSHxwrKTKJrwfoR/LcQJZfmiWJcM5d9Rp7afMChxOcdGdkSdIwrNBC8SCcHRenA3GsZ6mg+j6px7KWYxJ34btA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.27.0.tgz",
-      "integrity": "sha512-MqIDyxODljn9ZC4oqjQD0kez2a4zjIJ9ywA/b7cIiUiK/tDjZNTVjYd9WXMKQlXnWUwfrfXJZClVVqN1iCXS+Q==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.1.tgz",
+      "integrity": "sha512-5oo4+I8iixie9vXhCyNFCzeIr8pqA3FQ//VsLHTDvZAV4ttYOPGvYHGQq5NSalrLx5Jc3dRro/5uDOlnUMcBJg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.1.tgz",
+      "integrity": "sha512-qCDoZfx5MpX7XQzvQ3bC4tSEMkQWQMaF/ABtLuoze03Y/flR563CCSws02qIJ23oX7lxl92LsilZjINVyTdtLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.1.tgz",
+      "integrity": "sha512-hnGs0/lsFJ2PWDxNBz7pxreXo/Xz7gxYRcfePBUjsH26ad0kU/sgnVZd9LwWBpsQv65z2jlb5dkyaB9WE9M9FQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.27.0.tgz",
-      "integrity": "sha512-OZqaFFVm+10hAlmxpiTWi/o2n+YKBESbSqSy2yXAumPH/kaK4moJHFblbh8IkV3KZR0lLm4hzPtn8Q2nWNiDUA==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.1.tgz",
+      "integrity": "sha512-2VxxNc/uBysyKvGeBdSM5n9eIDKH8kWD7wd9/yqbJAiVwU4Yv6tU1LSJusHKrXV/aCu1KW7t9Gug9QyeEmtn/Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.1.tgz",
+      "integrity": "sha512-O6mPtsw3xEfNOe6gWFpYLeAZAIljNa4Hgna3bq15PwyN7nbjTY0wXJFRbzs/0YVf75Br+SbOQUmjKxXYjDiSiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-      "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
+      "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -161,73 +196,85 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==",
       "license": "MIT"
     },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.27.0.tgz",
-      "integrity": "sha512-pIrmQRXtDV+zTMVXKtKCosC2rWhn0F0TdUeb9etA6RiAz6jY6bY6f0+JX7YekDK09SnmZMLIyUa7Jci+Ied9bw==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.27.0.tgz",
-      "integrity": "sha512-UWvta8BxsR/u5z9eI088mOSLQaGtmoCtXeN3DYJurlxAdJwPuKtEb5+433kxA6/E9f2/JgoW89KZ1vNP9pcHBQ==",
+    "node_modules/@algolia/ingestion": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.1.tgz",
+      "integrity": "sha512-U9zZfc5xIu9wRxZkt+HceJUAD4VKHKbAyLSloJdEyMRmphXeibfrY9cxqIXBcmPeZzGhn3Imb35Dq8l19PkJhw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/logger-common": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.1.tgz",
+      "integrity": "sha512-a3SGNceHmkQfq77iG8Ka+w1pvwfZa/0lzEIgse30fL0kD+yKnd/dg0dQvSfFPAEt2f21DMcGkDSSeJlO3KdQjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.27.0.tgz",
-      "integrity": "sha512-CFy54xDjrsazPi3KN04yPmLRDT72AKokc3RLOdWQvG0/uEUjj7dhWqe9qenxpL4ydsjO7S1eY5YqmX+uMGonlg==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.1.tgz",
+      "integrity": "sha512-z98QEguCFDpxb4S/PyrUK1igqF8tPsdbqOUUO6ON91vJ58w+Gwa6ncrI0oNXSFcrkxA5EqPKPQ2A1PBCn08TYQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.27.0",
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/cache-in-memory": "4.27.0",
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/logger-console": "4.27.0",
-        "@algolia/requester-browser-xhr": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/requester-node-http": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.27.0.tgz",
-      "integrity": "sha512-dTenMBIIpyp5o3C2ZnfbsuSlD/lL9jPkk6T+2+qm38fyw2nf49ANbcHFE79NgiGrnmw7QrYveCs9NIP3Wk4v6g==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.1.tgz",
+      "integrity": "sha512-CI7+/0I11QeZM59Uc8whd2or0kqzFVjpaPn9Qpwll/krHcBAxk24WkAQ6WX+IwDVMfpont4YGbKwAmCre3vE8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.27.0"
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.27.0.tgz",
-      "integrity": "sha512-VC3prAQVgWTubMStb3mJz6i61Hqbtagi2LeIbgNtoFJFff3XZDcAaO1D5r0GYl2+DrB2VzUHnQXbkiuI+HHYyg==",
-      "license": "MIT"
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.1.tgz",
+      "integrity": "sha512-S6bDuw9byfOvm3T71cgdoZgrgnZq6hpdMLkx52Louh57nUAmvGQESz2aojOynQHjbTiV55smvAFbgn0qT4tJrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.27.0.tgz",
-      "integrity": "sha512-y8nUqaUQeSOQ5oaNo0b2QPznyBFW9LoIwljyUphJ+gUZpU6O/j2/C8ovoqDpIe6J0etqHg5RCcBizrCFZuLpyw==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.1.tgz",
+      "integrity": "sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.27.0.tgz",
-      "integrity": "sha512-PvSbELU4VjN3xSX79ki+zIdOGhTxyJXWvRDzkUjfTx2iNfPWDdTjzKbP1o+268coJztxrkuBwJz90Urek7o1Kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0"
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1272,26 +1319,28 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.27.0.tgz",
-      "integrity": "sha512-C88C5grLa5VOCp9eYZJt+q99ik7yNdm92l7Q9+4XK0Md8kL05Lg8l2v9ZVX0uMW3mH9pAFxMMXlLOvqNumA4lw==",
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
+      "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.27.0",
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/cache-in-memory": "4.27.0",
-        "@algolia/client-account": "4.27.0",
-        "@algolia/client-analytics": "4.27.0",
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-personalization": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/logger-console": "4.27.0",
-        "@algolia/recommend": "4.27.0",
-        "@algolia/requester-browser-xhr": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/requester-node-http": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/abtesting": "1.18.1",
+        "@algolia/client-abtesting": "5.52.1",
+        "@algolia/client-analytics": "5.52.1",
+        "@algolia/client-common": "5.52.1",
+        "@algolia/client-insights": "5.52.1",
+        "@algolia/client-personalization": "5.52.1",
+        "@algolia/client-query-suggestions": "5.52.1",
+        "@algolia/client-search": "5.52.1",
+        "@algolia/ingestion": "1.52.1",
+        "@algolia/monitoring": "1.52.1",
+        "@algolia/recommend": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,9 @@
     "dist-es5-module/"
   ],
   "main": "dist-es5-module/index.js",
+  "browser": {
+    "algoliasearch/lite": "./node_modules/algoliasearch/dist/lite/builds/browser.umd.js"
+  },
   "browserify-shim": {
     "moment": "global:moment"
   },
@@ -28,7 +31,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "algoliasearch": "^4.27.0",
+    "algoliasearch": "^5.52.1",
     "autocomplete.js": "^0.28.1",
     "hogan.js": "^3.0.2",
     "instantsearch.js": "^4.96.1",

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -1,5 +1,3 @@
-// Small hack to remove verticalAlign on the input
-// Makes IE11 fail though
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import autocomplete from 'autocomplete.js';
 import _ from 'autocomplete.js/src/common/utils';
@@ -10,6 +8,8 @@ import { createClickTracker } from './clickAnalytics';
 import removeCSS from './removeCSS';
 import getOptionalWords from './stopwords';
 
+// Small hack to remove verticalAlign on the input
+// Makes IE11 fail though
 if (!_.isMsie()) {
   const css = require('autocomplete.js/src/autocomplete/css');
   delete css.input.verticalAlign;

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -1,6 +1,6 @@
 // Small hack to remove verticalAlign on the input
 // Makes IE11 fail though
-import algoliasearch from 'algoliasearch';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import autocomplete from 'autocomplete.js';
 import _ from 'autocomplete.js/src/common/utils';
 import zepto from 'autocomplete.js/zepto';
@@ -35,7 +35,6 @@ class Autocomplete {
     this.client = algoliasearch(applicationId, apiKey);
     this.client.addAlgoliaAgent('Zendesk Integration (__VERSION__)');
     this.indexName = indexName || `${indexPrefix}${subdomain}_articles`;
-    this.index = this.client.initIndex(this.indexName);
     this.trackClick = createClickTracker(this, this.indexName);
   }
 
@@ -140,13 +139,19 @@ class Autocomplete {
 
   _source(params, locale, clickAnalytics) {
     return (query, callback) => {
-      this.index
-        .search(query, {
-          ...params,
-          clickAnalytics,
-          optionalWords: getOptionalWords(query, locale),
+      this.client
+        .searchForHits({
+          requests: [
+            {
+              indexName: this.indexName,
+              ...params,
+              clickAnalytics,
+              query,
+              optionalWords: getOptionalWords(query, locale),
+            },
+          ],
         })
-        .then((content) => {
+        .then(({ results: [content] }) => {
           const hitsWithPosition = this._addPositionToHits(
             content.hits,
             content.queryID,

--- a/app/src/instantsearch.js
+++ b/app/src/instantsearch.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 
 import addCSS from './addCSS';


### PR DESCRIPTION
Upgrade algoliasearch from v4 to v5.

https://www.algolia.com/doc/libraries/sdk/upgrade/javascript

Note:

Added a `browser` field in `package.json` aliasing algoliasearch/lite to its UMD browser build, working around Browserify v13 not honouring exports. Without it, the bundle picks up the Node build + browserify-zlib and grows by ~1.2 MB.

### Test :test_tube:

- `cd app/ && npm install`
- `npm run dev`
- open https://d3v-algolia.zendesk.com/hc/en-us, which is setup to point on `localhost:3000`

---
DI-4679