### PR TITLE
feat(UI): upgrade autocomplete to v1

### DIFF
--- a/app/css/index.scss
+++ b/app/css/index.scss
@@ -351,7 +351,9 @@
     margin-top: 5px;
     opacity: .7;
 
-    .ais-highlight {
+    mark {
+      background: none;
+      color: inherit;
       font-weight: bold;
     }
   }
@@ -365,9 +367,11 @@
     cursor: pointer;
   }
 
-  .search-result-link .ais-highlight {
+  .search-result-link mark {
     position: relative;
     z-index: 1;
+    background: none;
+    color: inherit;
 
     &::before {
       content: "";

--- a/app/css/index.scss
+++ b/app/css/index.scss
@@ -220,9 +220,11 @@
   font-size: 1.1em;
   font-weight: bold;
 
-  .aa-article-hit--highlight {
+  mark {
     position: relative;
     z-index: 1;
+    background: none;
+    color: inherit;
 
     &::before {
       content: "";
@@ -261,7 +263,8 @@
   margin-top: 4px;
   line-height: 1.25em;
 
-  .aa-article-hit--highlight {
+  mark {
+    background: none;
     color: #666;
     font-weight: bold;
   }

--- a/app/css/index.scss
+++ b/app/css/index.scss
@@ -29,12 +29,13 @@
     content: "\1F50D";
     font-family: "entypo";
     font-size: 1.25em;
-    line-height: 0;
+    line-height: 1;
     position: absolute;
     text-align: center;
-    top: 18px;
+    top: 50%;
     left: 0;
     width: 2.2em;
+    transform: translateY(-50%);
     z-index: 1;
   }
 }
@@ -46,6 +47,8 @@
 .aa-Input {
   box-sizing: border-box;
   width: 100%;
+  height: 100%;
+  margin: 0;
   outline: none;
   padding: 10px;
   padding-left: 32px;
@@ -78,6 +81,12 @@
   font-size: 14px;
   padding: 20px 16px 16px 16px;
   text-align: left;
+}
+
+.aa-List {
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .aa-Item {

--- a/app/css/index.scss
+++ b/app/css/index.scss
@@ -16,25 +16,60 @@
 }
 
 /***************************/
-/* autocomplete.js */
+/* @algolia/autocomplete-js */
 /***************************/
 
-.algolia-autocomplete {
-  width: 100%;
+.aa-zendesk-container {
   line-height: normal;
 }
 
-.aa-input {
+.aa-Form {
+  position: relative;
+  &:before {
+    content: "\1F50D";
+    font-family: "entypo";
+    font-size: 1.25em;
+    line-height: 0;
+    position: absolute;
+    text-align: center;
+    top: 18px;
+    left: 0;
+    width: 2.2em;
+    z-index: 1;
+  }
+}
+
+.aa-InputWrapperPrefix {
+  display: none;
+}
+
+.aa-Input {
+  box-sizing: border-box;
   width: 100%;
   outline: none;
+  padding: 10px;
+  padding-left: 32px;
+  padding-right: 28px;
 }
 
-.aa-hint {
-  width: 100%;
-  color: #999;
+.aa-InputWrapperSuffix {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
 }
 
-.aa-dropdown-menu {
+.aa-ClearButton {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+}
+
+.aa-Panel {
+  position: absolute;
+  z-index: 10000;
   margin-top: 9px;
   border: 1px solid #d9d9d9;
   border-radius: 3px;
@@ -43,10 +78,9 @@
   font-size: 14px;
   padding: 20px 16px 16px 16px;
   text-align: left;
-  position: relative;
 }
 
-.aa-suggestion {
+.aa-Item {
   cursor: pointer;
   padding-top: 5px;
 }
@@ -146,7 +180,8 @@
   padding: 4px 10% 4px 8px;
 }
 
-.aa-suggestion.aa-cursor .aa-article-hit--content {
+.aa-Item:hover .aa-article-hit--content,
+.aa-Item[aria-selected="true"] .aa-article-hit--content {
   background-color: #f8f8f8;
 }
 

--- a/app/css/index.scss
+++ b/app/css/index.scss
@@ -19,10 +19,6 @@
 /* @algolia/autocomplete-js */
 /***************************/
 
-.aa-zendesk-container {
-  line-height: normal;
-}
-
 .aa-Form {
   position: relative;
   &:before {

--- a/app/index.html
+++ b/app/index.html
@@ -73,11 +73,11 @@
       });
 
       var $master = document.querySelector('input[name=master]');
-      console.log($master);
       $master.addEventListener('input', function () {
-        search.search.autocompletes.forEach(function (autocomplete) {
-          autocomplete.autocomplete.setVal($master.value);
-          autocomplete.autocomplete.open();
+        search.search.autocompletes.forEach(function (aa) {
+          aa.setQuery($master.value);
+          aa.refresh();
+          aa.setIsOpen(true);
         });
       });
     </script>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.32.0",
       "license": "MIT",
       "dependencies": {
+        "@algolia/autocomplete-js": "^1.19.8",
         "algoliasearch": "^5.52.1",
-        "autocomplete.js": "^0.28.1",
         "hogan.js": "^3.0.2",
         "instantsearch.js": "^4.96.1",
         "js-cookie": "^2.2.1",
@@ -89,6 +89,68 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
+      "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
+        "@algolia/autocomplete-shared": "1.19.8"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.19.8.tgz",
+      "integrity": "sha512-9Sfr9Un3vObdtnj6IqzxoD9XisjFJxA9WAyVxmOkwTD9aVluyNwDeEWeGLy12xhRyILjA5C7byto159cZcdEEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.19.8",
+        "@algolia/autocomplete-preset-algolia": "1.19.8",
+        "@algolia/autocomplete-shared": "1.19.8",
+        "htm": "^3.1.1",
+        "preact": "^10.13.2"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.5.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
+      "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.8"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.19.8.tgz",
+      "integrity": "sha512-5XhJe5uXXLrt+C1MjIv1/BfGNHZyD1xkAYMVANTjdY+PXwO4o+3YIK2XGU0MxHTGryy70G6+xVO9TB7xA+3hGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.8"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
+      "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/client-abtesting": {
@@ -1947,14 +2009,6 @@
       },
       "engines": {
         "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/autocomplete.js": {
-      "version": "0.28.3",
-      "resolved": "https://registry.npmjs.org/autocomplete.js/-/autocomplete.js-0.28.3.tgz",
-      "integrity": "sha512-hW3Qz0gMOkkx59PdCLHtXz52FRKdk0gypsraRZW0Fp5407MykimPs6+Afovl630mnstbmTrjVqz+l2WckfE75w==",
-      "dependencies": {
-        "immediate": "^3.2.3"
       }
     },
     "node_modules/autoprefixer": {
@@ -9582,11 +9636,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "node_modules/immutable": {
       "version": "4.3.4",

--- a/app/package.json
+++ b/app/package.json
@@ -31,8 +31,8 @@
     "node": ">=22"
   },
   "dependencies": {
+    "@algolia/autocomplete-js": "^1.19.8",
     "algoliasearch": "^5.52.1",
-    "autocomplete.js": "^0.28.1",
     "hogan.js": "^3.0.2",
     "instantsearch.js": "^4.96.1",
     "js-cookie": "^2.2.1",

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -45,7 +45,7 @@ class Autocomplete {
     if (!enabled) return null;
 
     this.$inputs = document.querySelectorAll(inputSelector);
-    this.$inputs = Array.prototype.slice.call(this.$inputs, 0);
+    this.$inputs = Array.prototype.slice.call(this.$inputs, 0); // Transform to array
     this._disableZendeskAutocomplete();
 
     addCSS(templates.autocomplete.css({ color, highlightColor }));
@@ -79,8 +79,6 @@ class Autocomplete {
       const aa = autocomplete({
         container: $container,
         placeholder: translations.placeholder,
-        // Always render inline; we're replacing host-theme search bars
-        // that are themselves inline.
         detachedMediaQuery: 'none',
         debug: process.env.NODE_ENV === 'development' || debug,
         onSubmit: ({ state }) => {
@@ -191,7 +189,9 @@ class Autocomplete {
   }
 
   _renderHeader({ poweredBy, subdomain, templates, translations }) {
-    if (poweredBy !== true) return undefined;
+    if (poweredBy !== true) {
+      return undefined;
+    }
     return templates.autocomplete.poweredBy({ subdomain, translations });
   }
 

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -1,20 +1,10 @@
+import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
-import autocomplete from 'autocomplete.js';
-import _ from 'autocomplete.js/src/common/utils';
-import zepto from 'autocomplete.js/zepto';
 
 import addCSS from './addCSS';
 import { createClickTracker } from './clickAnalytics';
 import removeCSS from './removeCSS';
 import getOptionalWords from './stopwords';
-
-// Small hack to remove verticalAlign on the input
-// Makes IE11 fail though
-if (!_.isMsie()) {
-  const css = require('autocomplete.js/src/autocomplete/css');
-  delete css.input.verticalAlign;
-  delete css.inputWithNoHint.verticalAlign;
-}
 
 const XS_WIDTH = 400;
 const SM_WIDTH = 600;
@@ -55,7 +45,7 @@ class Autocomplete {
     if (!enabled) return null;
 
     this.$inputs = document.querySelectorAll(inputSelector);
-    this.$inputs = Array.prototype.slice.call(this.$inputs, 0); // Transform to array
+    this.$inputs = Array.prototype.slice.call(this.$inputs, 0);
     this._disableZendeskAutocomplete();
 
     addCSS(templates.autocomplete.css({ color, highlightColor }));
@@ -64,53 +54,90 @@ class Autocomplete {
     for (let i = 0; i < this.$inputs.length; ++i) {
       const $input = this.$inputs[i];
 
-      // Get the width of the dropdown
-      const dropdownMenuWidth = $input.getBoundingClientRect().width;
+      // v1's `autocomplete()` requires a div container; it renders its own
+      // input + form inside. We hide the Zendesk theme's input rather than
+      // removing it, so any host-theme JS that references `#query` (form
+      // submit handlers, custom listeners) keeps working. v1 mounts in a
+      // sibling container of the same dimensions.
+      const inputRect = $input.getBoundingClientRect();
+      const containerWidth = inputRect.width;
+      const $container = document.createElement('div');
+      $container.className = 'aa-zendesk-container';
+      $container.style.width = `${containerWidth}px`;
+      $input.parentNode.insertBefore($container, $input.nextSibling);
+      $input.style.display = 'none';
 
-      const sizeModifier = this._sizeModifier(dropdownMenuWidth);
-      const nbSnippetWords = this._nbSnippetWords(dropdownMenuWidth);
+      const sizeModifier = this._sizeModifier(containerWidth);
+      const nbSnippetWords = this._nbSnippetWords(containerWidth);
       const params = {
         analytics,
         hitsPerPage,
-        facetFilters: `["locale.locale:${locale}"]`,
+        facetFilters: [`locale.locale:${locale}`],
         highlightPreTag: '<span class="aa-article-hit--highlight">',
         highlightPostTag: '</span>',
         attributesToSnippet: [`body_safe:${nbSnippetWords}`],
         snippetEllipsisText: '...',
       };
 
-      $input.setAttribute('placeholder', translations.placeholder);
-      const aa = autocomplete(
-        $input,
-        {
-          hint: false,
-          debug: process.env.NODE_ENV === 'development' || debug,
-          templates: this._templates({
-            poweredBy,
-            subdomain,
-            templates,
-            translations,
-          }),
-          appendTo: 'body',
+      const aa = autocomplete({
+        container: $container,
+        placeholder: translations.placeholder,
+        // Always render inline; we're replacing host-theme search bars
+        // that are themselves inline.
+        detachedMediaQuery: 'none',
+        debug: process.env.NODE_ENV === 'development' || debug,
+        onSubmit: ({ state }) => {
+          window.location.href = `${baseUrl}${locale}/search?query=${encodeURIComponent(
+            state.query
+          )}`;
         },
-        [
+        getSources: ({ query }) => [
           {
-            source: this._source(params, locale, clickAnalytics),
-            name: 'articles',
+            sourceId: 'articles',
+            getItems: () =>
+              getAlgoliaResults({
+                searchClient: this.client,
+                queries: [
+                  {
+                    indexName: this.indexName,
+                    query,
+                    params: {
+                      ...params,
+                      clickAnalytics,
+                      optionalWords: getOptionalWords(query, locale),
+                    },
+                  },
+                ],
+                transformResponse: ({ hits, results }) => [
+                  this._reorderedHits(
+                    this._addPositionToHits(
+                      hits[0],
+                      results[0].queryID,
+                      clickAnalytics
+                    )
+                  ),
+                ],
+              }),
+            getItemUrl: ({ item }) => `${baseUrl}${locale}/articles/${item.id}`,
+            onSelect: ({ item }) => {
+              if (clickAnalytics) {
+                this.trackClick(item, item._position, item._queryID);
+              }
+              window.location.href = `${baseUrl}${locale}/articles/${item.id}`;
+            },
             templates: {
-              suggestion: this._renderSuggestion(templates, sizeModifier),
+              header: this._renderHeader({
+                poweredBy,
+                subdomain,
+                templates,
+                translations,
+              }),
+              item: this._renderItem(templates, sizeModifier),
             },
           },
-        ]
-      );
-      aa.on(
-        'autocomplete:selected',
-        this._onSelected(baseUrl, locale, clickAnalytics)
-      );
-      aa.on('autocomplete:redrawn', function () {
-        aa.autocomplete.getWrapper().style.zIndex = 10000;
+        ],
       });
-      aa.typeahead = zepto($input).data('aaAutocomplete');
+
       this.autocompletes.push(aa);
     }
 
@@ -118,8 +145,8 @@ class Autocomplete {
   }
 
   enableDebugMode() {
-    this.autocompletes.forEach(function (aa) {
-      aa.typeahead.debug = true;
+    this.autocompletes.forEach((aa) => {
+      aa.setIsOpen(true);
     });
   }
 
@@ -135,32 +162,6 @@ class Autocomplete {
     if (inputWidth < XS_WIDTH) return 0;
     if (inputWidth < SM_WIDTH) return 3 + Math.floor(inputWidth / 45);
     return Math.floor(inputWidth / 35);
-  }
-
-  _source(params, locale, clickAnalytics) {
-    return (query, callback) => {
-      this.client
-        .searchForHits({
-          requests: [
-            {
-              indexName: this.indexName,
-              ...params,
-              clickAnalytics,
-              query,
-              optionalWords: getOptionalWords(query, locale),
-            },
-          ],
-        })
-        .then(({ results: [content] }) => {
-          const hitsWithPosition = this._addPositionToHits(
-            content.hits,
-            content.queryID,
-            clickAnalytics
-          );
-          const reorderedHits = this._reorderedHits(hitsWithPosition);
-          callback(reorderedHits);
-        });
-    };
   }
 
   _reorderedHits(hits) {
@@ -192,32 +193,25 @@ class Autocomplete {
     return flattenedHits;
   }
 
-  _templates({ poweredBy, subdomain, templates, translations }) {
-    const res = {};
-    if (poweredBy === true) {
-      res.header = templates.autocomplete.poweredBy({
-        content: translations.search_by_algolia(
-          templates.autocomplete.algolia(subdomain)
-        ),
-      });
-    }
-    return res;
+  _renderHeader({ poweredBy, subdomain, templates, translations }) {
+    if (poweredBy !== true) return undefined;
+    const html = templates.autocomplete.poweredBy({
+      content: translations.search_by_algolia(
+        templates.autocomplete.algolia(subdomain)
+      ),
+    });
+    return ({ html: h }) =>
+      h`<div dangerouslySetInnerHTML=${{ __html: html }} />`;
   }
 
-  _renderSuggestion(templates, sizeModifier) {
-    return (hit) => {
-      hit.sizeModifier = sizeModifier;
-      return templates.autocomplete.article(hit);
-    };
-  }
-
-  _onSelected(baseUrl, locale, clickAnalytics) {
-    return (event, suggestion, dataset) => {
-      if (clickAnalytics) {
-        const { _position, _queryID } = suggestion;
-        this.trackClick(suggestion, _position, _queryID);
-      }
-      location.href = `${baseUrl}${locale}/${dataset}/${suggestion.id}`;
+  _renderItem(templates, sizeModifier) {
+    return ({ item, html }) => {
+      const decorated = { ...item, sizeModifier };
+      return html`<div
+        dangerouslySetInnerHTML=${{
+          __html: templates.autocomplete.article(decorated),
+        }}
+      />`;
     };
   }
 
@@ -252,7 +246,7 @@ class Autocomplete {
 
   _addPositionToHits(hits, queryID, clickAnalytics) {
     if (!clickAnalytics) return hits;
-    return hits.map(function (hit, index) {
+    return hits.map((hit, index) => {
       hit._position = index + 1;
       hit._queryID = queryID;
       return hit;

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -73,8 +73,6 @@ class Autocomplete {
         analytics,
         hitsPerPage,
         facetFilters: [`locale.locale:${locale}`],
-        highlightPreTag: '<span class="aa-article-hit--highlight">',
-        highlightPostTag: '</span>',
         attributesToSnippet: [`body_safe:${nbSnippetWords}`],
         snippetEllipsisText: '...',
       };
@@ -195,24 +193,11 @@ class Autocomplete {
 
   _renderHeader({ poweredBy, subdomain, templates, translations }) {
     if (poweredBy !== true) return undefined;
-    const html = templates.autocomplete.poweredBy({
-      content: translations.search_by_algolia(
-        templates.autocomplete.algolia(subdomain)
-      ),
-    });
-    return ({ html: h }) =>
-      h`<div dangerouslySetInnerHTML=${{ __html: html }} />`;
+    return templates.autocomplete.poweredBy({ subdomain, translations });
   }
 
   _renderItem(templates, sizeModifier) {
-    return ({ item, html }) => {
-      const decorated = { ...item, sizeModifier };
-      return html`<div
-        dangerouslySetInnerHTML=${{
-          __html: templates.autocomplete.article(decorated),
-        }}
-      />`;
-    };
+    return templates.autocomplete.article(sizeModifier);
   }
 
   _temporaryHiding(selector) {

--- a/app/src/autocomplete.js
+++ b/app/src/autocomplete.js
@@ -62,7 +62,6 @@ class Autocomplete {
       const inputRect = $input.getBoundingClientRect();
       const containerWidth = inputRect.width;
       const $container = document.createElement('div');
-      $container.className = 'aa-zendesk-container';
       $container.style.width = `${containerWidth}px`;
       $input.parentNode.insertBefore($container, $input.nextSibling);
       $input.style.display = 'none';

--- a/app/src/instantsearch.js
+++ b/app/src/instantsearch.js
@@ -36,8 +36,6 @@ class InstantSearch {
     this.baseSearchParameters = {
       analytics,
       attributesToSnippet: ['body_safe:40'],
-      highlightPreTag: '<span class="ais-highlight">',
-      highlightPostTag: '</span>',
       snippetEllipsisText: '...',
       clickAnalytics,
     };

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -100,11 +100,11 @@ const defaultTemplates = {
   color: [[ color ]];
 }
 
-.search-result-link .ais-highlight {
+.search-result-link mark {
   color: [[ highlightColor ]];
 }
 
-.search-result-link .ais-highlight::before {
+.search-result-link mark::before {
   background-color: [[ highlightColor ]];
 }
 

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -45,30 +45,19 @@ const defaultTemplates = {
         `;
       },
 
-    // Powered By header. Returns a v1-compatible template function.
-    // The link is composed as vdom; the localized "Search by ..." wrapper
-    // text is spliced in via a sentinel so translations stay as plain
-    // text (no HTML injection from translation values).
     poweredBy:
       ({ translations }) =>
       ({ html }) => {
-        const SENTINEL = '\x00LINK\x00';
-        const wrapped = translations.search_by_algolia(SENTINEL);
-        const [before = '', after = ''] = wrapped.split(SENTINEL);
-        const link = html`
-          <a
-            class="aa-powered-by-link"
-            href=${`https://www.algolia.com/?utm_source=zendesk&utm_medium=website&utm_content=${encodeURIComponent(
-              window.location.hostname
-            )}&utm_campaign=poweredby`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Algolia
-          </a>
-        `;
+        const link = `<a class="aa-powered-by-link" href="https://www.algolia.com/?utm_source=zendesk&utm_medium=website&utm_content=${encodeURIComponent(
+          window.location.hostname
+        )}&utm_campaign=poweredby" target="_blank" rel="noopener noreferrer">Algolia</a>`;
         return html`
-          <div class="aa-powered-by">${before}${link}${after}</div>
+          <div
+            class="aa-powered-by"
+            dangerouslySetInnerHTML=${{
+              __html: translations.search_by_algolia(link),
+            }}
+          ></div>
         `;
       },
 

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -52,7 +52,7 @@ const defaultTemplates = {
     // text is spliced in via a sentinel so translations stay as plain
     // text (no HTML injection from translation values).
     poweredBy:
-      ({ subdomain, translations }) =>
+      ({ translations }) =>
       ({ html }) => {
         const SENTINEL = '\x00LINK\x00';
         const wrapped = translations.search_by_algolia(SENTINEL);
@@ -60,7 +60,9 @@ const defaultTemplates = {
         const link = html`
           <a
             class="aa-powered-by-link"
-            href=${`https://www.algolia.com/?utm_source=zendesk&utm_medium=link&utm_campaign=autocomplete-${subdomain}`}
+            href=${`https://www.algolia.com/?utm_source=zendesk&utm_medium=website&utm_content=${encodeURIComponent(
+              window.location.hostname
+            )}&utm_campaign=poweredby`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -52,12 +52,9 @@ const defaultTemplates = {
           window.location.hostname
         )}&utm_campaign=poweredby" target="_blank" rel="noopener noreferrer">Algolia</a>`;
         return html`
-          <div
-            class="aa-powered-by"
-            dangerouslySetInnerHTML=${{
-              __html: translations.search_by_algolia(link),
-            }}
-          ></div>
+          <div class="aa-powered-by">
+            ${html([translations.search_by_algolia(link)])}
+          </div>
         `;
       },
 

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -2,9 +2,7 @@ import compile from './compile';
 
 const defaultTemplates = {
   autocomplete: {
-    // Autocompletion template for an article.
-    // Curried with `sizeModifier` so the inner function matches the
-    // `@algolia/autocomplete-js` template signature `({ item, html }) => vdom`.
+    // Autocompletion template for an article
     article:
       (sizeModifier) =>
       ({ item, html, components }) => {

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -2,74 +2,96 @@ import compile from './compile';
 
 const defaultTemplates = {
   autocomplete: {
-    // Algolia logo
-    algolia: (subdomain) =>
-      `<a
-  href="https://www.algolia.com/?utm_source=zendesk&utm_medium=link&utm_campaign=autocomplete-${subdomain}"
-  class="aa-powered-by-link"
->
-  Algolia
-</a>`,
+    // Autocompletion template for an article.
+    // Curried with `sizeModifier` so the inner function matches the
+    // `@algolia/autocomplete-js` template signature `({ item, html }) => vdom`.
+    article:
+      (sizeModifier) =>
+      ({ item, html, components }) => {
+        const className = [
+          'aa-article-hit',
+          item.isCategoryHeader && 'aa-article-hit__category-first',
+          item.isSectionHeader && 'aa-article-hit__section-first',
+          sizeModifier && `aa-article-hit__${sizeModifier}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
 
-    // Autocompletion template for an article
-    article: compile(
-      `<div
-  class="
-    aa-article-hit
-    [[# isCategoryHeader ]]aa-article-hit__category-first[[/ isCategoryHeader ]]
-    [[# isSectionHeader ]]aa-article-hit__section-first[[/ isSectionHeader ]]
-    [[# sizeModifier ]]aa-article-hit__[[ sizeModifier ]][[/ sizeModifier]]
-  "
->
-  <div class="aa-article-hit--category">
-    <span class="aa-article-hit--category--content">
-      [[ category.title ]]
-    </span>
-  </div>
-  <div class="aa-article-hit--line">
-    <div class="aa-article-hit--section">
-      [[ section.title ]]
-    </div>
-    <div class="aa-article-hit--content">
-      <div class="aa-article-hit--headline">
-        <span class="aa-article-hit--title">
-          [[& _highlightResult.title.value ]]
-        </span>
-      </div>
-      [[# _snippetResult.body_safe.value ]]
-        <div class="aa-article-hit--body">[[& _snippetResult.body_safe.value ]]</div>
-      [[/ _snippetResult.body_safe.value ]]
-    </div>
-  </div>
-</div>
-<div class="clearfix"></div>`
-    ),
+        return html`
+          <div class=${className}>
+            <div class="aa-article-hit--category">
+              <span class="aa-article-hit--category--content">
+                ${item.category.title}
+              </span>
+            </div>
+            <div class="aa-article-hit--line">
+              <div class="aa-article-hit--section">
+                ${item.section.title}
+              </div>
+              <div class="aa-article-hit--content">
+                <div class="aa-article-hit--headline">
+                  <span class="aa-article-hit--title">
+                    ${components.Highlight({ hit: item, attribute: 'title' })}
+                  </span>
+                </div>
+                ${item._snippetResult &&
+                item._snippetResult.body_safe &&
+                item._snippetResult.body_safe.value &&
+                html`
+                  <div class="aa-article-hit--body">
+                    ${components.Snippet({ hit: item, attribute: 'body_safe' })}
+                  </div>
+                `}
+              </div>
+            </div>
+          </div>
+          <div class="clearfix"></div>
+        `;
+      },
 
-    // Powered By
-    poweredBy: compile(
-      `<div class="aa-powered-by">
-  [[& content ]]
-</div>`
-    ),
+    // Powered By header. Returns a v1-compatible template function.
+    // The link is composed as vdom; the localized "Search by ..." wrapper
+    // text is spliced in via a sentinel so translations stay as plain
+    // text (no HTML injection from translation values).
+    poweredBy:
+      ({ subdomain, translations }) =>
+      ({ html }) => {
+        const SENTINEL = '\x00LINK\x00';
+        const wrapped = translations.search_by_algolia(SENTINEL);
+        const [before = '', after = ''] = wrapped.split(SENTINEL);
+        const link = html`
+          <a
+            class="aa-powered-by-link"
+            href=${`https://www.algolia.com/?utm_source=zendesk&utm_medium=link&utm_campaign=autocomplete-${subdomain}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Algolia
+          </a>
+        `;
+        return html`
+          <div class="aa-powered-by">${before}${link}${after}</div>
+        `;
+      },
 
     // CSS to add to handle the color
-    css: compile(
-      `.aa-article-hit--highlight {
-  color: [[ color ]];
+    css: ({ color, highlightColor }) => `
+.aa-article-hit mark {
+  color: ${color};
 }
 
 .aa-article-hit--section {
-  color: [[ color ]];
+  color: ${color};
 }
 
-.aa-article-hit--title .aa-article-hit--highlight {
-  color: [[ highlightColor ]];
+.aa-article-hit--title mark {
+  color: ${highlightColor};
 }
 
-.aa-article-hit--title .aa-article-hit--highlight::before {
-  background-color: [[ highlightColor ]];
-}`
-    ),
+.aa-article-hit--title mark::before {
+  background-color: ${highlightColor};
+}
+`,
   },
 
   instantsearch: {

--- a/app/src/templates.js
+++ b/app/src/templates.js
@@ -25,13 +25,11 @@ const defaultTemplates = {
               </span>
             </div>
             <div class="aa-article-hit--line">
-              <div class="aa-article-hit--section">
-                ${item.section.title}
-              </div>
+              <div class="aa-article-hit--section">${item.section.title}</div>
               <div class="aa-article-hit--content">
                 <div class="aa-article-hit--headline">
                   <span class="aa-article-hit--title">
-                    ${components.Highlight({ hit: item, attribute: 'title' })}
+                    <${components.Highlight} hit=${item} attribute="title" />
                   </span>
                 </div>
                 ${item._snippetResult &&
@@ -39,7 +37,7 @@ const defaultTemplates = {
                 item._snippetResult.body_safe.value &&
                 html`
                   <div class="aa-article-hit--body">
-                    ${components.Snippet({ hit: item, attribute: 'body_safe' })}
+                    <${components.Snippet} hit=${item} attribute="body_safe" />
                   </div>
                 `}
               </div>


### PR DESCRIPTION
Upgrade autocomplete from autocomplete.js@0.28 to @algolia/autocomplete-js@1:

- v1 requires a `<div>` container instead of an `<input>`.
  - Wrapped (and hidden) the default HelpCenter's `<input>` and mounted v1 in a sibling `div`.
- Templates moved off Hogan to use v1's `html` tagged function and the built-in `components.Highlight` and `components.Snippet`.

Unrelated:
- Missed during InstantSearch upgrade: IS v4's `escapeHTML: true` creates `<mark>` tags, so former `<span class="ais-highlight">` markers and CSS were dead. Updated the CSS to use `<mark>` selectors.

### How to test

- cd app/ && npm install
- npm run dev
- open http://localhost:3000
  - https://d3v-algolia.zendesk.com/hc/en-us is also setup to point on `localhost:3000`

---
DI-4679