### PR TITLE
chore: update package lock and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,16 @@ This integration makes it easy to replace the default search of your Zendesk Hel
 We'll crawl your Zendesk API to extract your Help Center content and provide you a small code snippet to power your search with Algolia.
 
 ## Indexing
-Find the code of the legacy crawler and its documentation in the [crawler/](./crawler/) folder.
-
-The ingestion is now performed by [Algolia's connectors platform][https://dashboard.algolia.com/connectors).
+The ingestion is performed by [Algolia's connectors platform][https://dashboard.algolia.com/connectors).
+Follow [the documentation](https://www.algolia.com/doc/integration/zendesk/get-started#set-up-the-algolia-connector) to setup your Zendesk connector.
 
 ## Front-end
-Follow the documentation [on the website](https://community.algolia.com/zendesk/documentation/).  
+Follow [the documentation](https://www.algolia.com/doc/integration/zendesk/get-started#update-your-theme) to update your Zendesk theme and replace the default search with Algolia.
 If you want to contribute or browse the code, follow [this link to the app/](./app/) folder.
 
 ## Development
 
-The `package.json` in this repository holds 3 scripts:
-- `npm run release:docs`: Release the documentation site on https://community.algolia.com/zendesk/
+The `package.json` in this repository has the following scripts:
 - `npm run release:app`: Release the JS library on `npm`
 - `npm run release`: Runs the previous scripts and `git push`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "conventional-changelog": "^0.5.3",
         "gh-pages": "^0.8.0",
-        "json": "^9.0.3"
+        "json": "^10.0.0"
       }
     },
     "node_modules/add-stream": {
@@ -745,9 +745,9 @@
       "dev": true
     },
     "node_modules/json": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
-      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/json/-/json-10.0.0.tgz",
+      "integrity": "sha512-iK7tAZtpoghibjdB1ncCWykeBMmke3JThUe+rnkD4qkZaglOIQ70Pw7r5UJ4lyUT+7gnw7ehmmLUHDuhqzQD+g==",
       "dev": true,
       "bin": {
         "json": "lib/json.js"


### PR DESCRIPTION
It seems that dependabot didn't run `npm install` in https://github.com/algolia/algoliasearch-zendesk/pull/133

- Update package-lock.json
- Update README (remove old link to the community website and point to the official docs)